### PR TITLE
feat: Add about page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,8 @@
+export default function AboutPage() {
+  return (
+    <div>
+      <h1>About Us</h1>
+      <p>This is the about page.</p>
+    </div>
+  );
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,8 +1,12 @@
 export default function AboutPage() {
   return (
-    <div>
-      <h1>About Us</h1>
-      <p>This is the about page.</p>
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
+        <h1 className="text-2xl font-bold">About Us</h1>
+        <p className="text-base text-gray-700 dark:text-gray-300 mt-4">
+          This is the about page.
+        </p>
+      </main>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -97,6 +97,19 @@ export default function Home() {
           />
           Go to nextjs.org →
         </a>
+        <a
+          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
+          href="/about"
+        >
+          <Image
+            aria-hidden
+            src="/globe.svg" // Assuming a generic icon, can be changed
+            alt="About icon"
+            width={16}
+            height={16}
+          />
+          About
+        </a>
       </footer>
     </div>
   );


### PR DESCRIPTION
Adds a new 'about' page to the application.

- Creates the route `/about` with a basic page component.
- Includes a heading "About Us" and placeholder text.
- Adds a link to the new "About" page in the footer of the main page.